### PR TITLE
Fix JSON + CSV export

### DIFF
--- a/app/controllers/attendees_controller.rb
+++ b/app/controllers/attendees_controller.rb
@@ -16,7 +16,7 @@ class AttendeesController < ApplicationController
     respond_to do |format|
       format.html
       format.json do
-        render json: @attendees.json
+        render json: @attendees.map(&:attrs).as_json
       end
       format.csv do
         if @attendees.present?

--- a/app/models/attendee.rb
+++ b/app/models/attendee.rb
@@ -170,15 +170,8 @@ class Attendee < ApplicationRecord
     CSV.generate(headers: true) do |csv|
       keys = CORE_PARAMS.map(&:to_s) + all.first.field_values.keys
       csv << keys
-      all.each do |item|
-        fixed = item.attrs.values
-        fixed.each_with_index do |value, index|
-          if value.class == NilClass || (value == '' || value == ' ')
-            fixed[index] = 'empty'
-            fixed[index] = 'empty'
-          end
-        end
-        csv << fixed
+      all.each do |a|
+        csv << a.attrs.values_at(*keys)
       end
     end
   end


### PR DESCRIPTION
For JSON: `.json` is not a method, only `.as_json` (or `.to_json`), so this is a 500 error right now. This exports the core & custom attributes correctly.

For CSV: simpler > custom.

Closes #25 

Closes #41